### PR TITLE
Factor out providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Creates an RDS database based on the `rds_plan_name` variable
 module "database" {
   source = "github.com/18f/terraform-cloudgov//database"
 
-  cf_user          = var.cf_user
-  cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   env              = "staging"
@@ -30,8 +28,6 @@ Creates a Elasticache redis instance
 module "redis" {
   source = "github.com/18f/terraform-cloudgov//redis"
 
-  cf_user          = var.cf_user
-  cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   env              = "staging"
@@ -48,8 +44,6 @@ Creates an s3 bucket and outputs the bucket_id
 module "s3" {
   source = "github.com/18f/terraform-cloudgov//s3"
 
-  cf_user          = var.cf_user
-  cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   s3_service_name  = "${local.app_name}-s3-${local.env}"
@@ -68,8 +62,6 @@ Note that the domain must be created in cloud.gov by an OrgManager before this m
 module "domain" {
   source = "github.com/18f/terraform-cloudgov//domain"
 
-  cf_user          = var.cf_user
-  cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   env              = "staging"
@@ -89,8 +81,6 @@ The scanning app requires at least 3GB of memory, and your app_name must be depl
 module "clamav" {
   source = "github.com/18f/terraform-cloudgov//clamav"
 
-  cf_user       = var.cf_user
-  cf_password   = var.cf_password
   cf_org_name   = local.cf_org_name
   cf_space_name = local.cf_space_name
   env           = "staging"
@@ -110,8 +100,6 @@ Creates a new cloud.gov space, such as when creating an egress space.
 module "egress_space" {
   source = "github.com/18f/terraform-cloudgov//cg_space"
 
-  cf_user       = var.cf_user
-  cf_password   = var.cf_password
   cf_org_name   = local.cf_org_name
   cf_space_name = "${local.cf_space_name}-egress"
   managers = [

--- a/cg_space/providers.tf
+++ b/cg_space/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = ">=0.15"
     }
   }
 }

--- a/cg_space/providers.tf
+++ b/cg_space/providers.tf
@@ -7,10 +7,3 @@ terraform {
     }
   }
 }
-
-provider "cloudfoundry" {
-  api_url      = var.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_password
-  app_logs_max = 30
-}

--- a/cg_space/variables.tf
+++ b/cg_space/variables.tf
@@ -1,20 +1,3 @@
-variable "cf_api_url" {
-  type        = string
-  description = "cloud.gov api url"
-  default     = "https://api.fr.cloud.gov"
-}
-
-variable "cf_user" {
-  type        = string
-  description = "cloud.gov deployer account user"
-}
-
-variable "cf_password" {
-  type        = string
-  description = "secret; cloud.gov deployer account password"
-  sensitive   = true
-}
-
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"

--- a/clamav/providers.tf
+++ b/clamav/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = ">=0.15"
     }
   }
 }

--- a/clamav/providers.tf
+++ b/clamav/providers.tf
@@ -7,10 +7,3 @@ terraform {
     }
   }
 }
-
-provider "cloudfoundry" {
-  api_url      = var.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_password
-  app_logs_max = 30
-}

--- a/clamav/variables.tf
+++ b/clamav/variables.tf
@@ -1,20 +1,3 @@
-variable "cf_api_url" {
-  type        = string
-  description = "cloud.gov api url"
-  default     = "https://api.fr.cloud.gov"
-}
-
-variable "cf_user" {
-  type        = string
-  description = "cloud.gov deployer account user"
-}
-
-variable "cf_password" {
-  type        = string
-  description = "secret; cloud.gov deployer account password"
-  sensitive   = true
-}
-
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"

--- a/database/providers.tf
+++ b/database/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = ">=0.15"
     }
   }
 }

--- a/database/providers.tf
+++ b/database/providers.tf
@@ -8,9 +8,3 @@ terraform {
   }
 }
 
-provider "cloudfoundry" {
-  api_url      = var.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_password
-  app_logs_max = 30
-}

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -1,20 +1,3 @@
-variable "cf_api_url" {
-  type        = string
-  description = "cloud.gov api url"
-  default     = "https://api.fr.cloud.gov"
-}
-
-variable "cf_user" {
-  type        = string
-  description = "cloud.gov deployer account user"
-}
-
-variable "cf_password" {
-  type        = string
-  description = "secret; cloud.gov deployer account password"
-  sensitive   = true
-}
-
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"

--- a/domain/providers.tf
+++ b/domain/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = ">=0.15"
     }
   }
 }

--- a/domain/providers.tf
+++ b/domain/providers.tf
@@ -7,10 +7,3 @@ terraform {
     }
   }
 }
-
-provider "cloudfoundry" {
-  api_url      = var.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_password
-  app_logs_max = 30
-}

--- a/domain/variables.tf
+++ b/domain/variables.tf
@@ -1,20 +1,3 @@
-variable "cf_api_url" {
-  type        = string
-  description = "cloud.gov api url"
-  default     = "https://api.fr.cloud.gov"
-}
-
-variable "cf_user" {
-  type        = string
-  description = "cloud.gov deployer account user"
-}
-
-variable "cf_password" {
-  type        = string
-  description = "secret; cloud.gov deployer account password"
-  sensitive   = true
-}
-
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"

--- a/redis/providers.tf
+++ b/redis/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = ">=0.15"
     }
   }
 }

--- a/redis/providers.tf
+++ b/redis/providers.tf
@@ -7,10 +7,3 @@ terraform {
     }
   }
 }
-
-provider "cloudfoundry" {
-  api_url      = var.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_password
-  app_logs_max = 30
-}

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -1,20 +1,3 @@
-variable "cf_api_url" {
-  type        = string
-  description = "cloud.gov api url"
-  default     = "https://api.fr.cloud.gov"
-}
-
-variable "cf_user" {
-  type        = string
-  description = "cloud.gov deployer account user"
-}
-
-variable "cf_password" {
-  type        = string
-  description = "secret; cloud.gov deployer account password"
-  sensitive   = true
-}
-
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"

--- a/s3/providers.tf
+++ b/s3/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = ">=0.15"
     }
   }
 }

--- a/s3/providers.tf
+++ b/s3/providers.tf
@@ -8,9 +8,3 @@ terraform {
   }
 }
 
-provider "cloudfoundry" {
-  api_url      = var.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_password
-  app_logs_max = 30
-}

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -1,20 +1,3 @@
-variable "cf_api_url" {
-  type        = string
-  description = "cloud.gov api url"
-  default     = "https://api.fr.cloud.gov"
-}
-
-variable "cf_user" {
-  type        = string
-  description = "cloud.gov deployer account user"
-}
-
-variable "cf_password" {
-  type        = string
-  description = "secret; cloud.gov deployer account password"
-  sensitive   = true
-}
-
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"


### PR DESCRIPTION
[Reusable modules should not configure their own providers, only state their requirements.](https://developer.hashicorp.com/terraform/language/modules/develop/providers#providers-within-modules) Providers should be configured (and if necessary, explicitly bound) by the calling module.

Modules should also not use `~>` when specifying their provider requirements, because new major versions may not break backward compatibility.