### PR TITLE
Remove assumptions about how the service will be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ module "database" {
   cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
-  env              = "staging"
-  app_name         = "application_name"
+  name             = "database_name"
   rds_plan_name    = "micro-psql"
 }
 ```
@@ -34,8 +33,7 @@ module "redis" {
   cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
-  env              = "staging"
-  app_name         = "application_name"
+  name             = "redis_name"
   redis_plan_name  = "redis-dev"
 }
 ```
@@ -52,7 +50,7 @@ module "s3" {
   cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
-  s3_service_name  = "${local.app_name}-s3-${local.env}"
+  name             = "${local.app_name}-s3-${local.env}"
 }
 ```
 
@@ -72,10 +70,9 @@ module "domain" {
   cf_password      = var.cf_password
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
-  env              = "staging"
-  app_name         = "application_name"
+  app_name_or_id   = "app_name"
   cdn_plan_name    = "domain"
-  domain_name      = "TKTK-production-domain-name"
+  domain_name      = "my-production-domain-name"
 }
 ```
 
@@ -93,8 +90,7 @@ module "clamav" {
   cf_password   = var.cf_password
   cf_org_name   = local.cf_org_name
   cf_space_name = local.cf_space_name
-  env           = "staging"
-  app_name      = "application_name"
+  name          = "my_clamav_name"
   clamav_image  = "ajilaag/clamav-rest:TAG_NAME"
   max_file_size = "30M"
 }

--- a/cg_space/main.tf
+++ b/cg_space/main.tf
@@ -1,14 +1,6 @@
-###
-# Target org
-###
-
 data "cloudfoundry_org" "org" {
   name = var.cf_org_name
 }
-
-###
-# New Space
-###
 
 resource "cloudfoundry_space" "space" {
   name = var.cf_space_name

--- a/clamav/main.tf
+++ b/clamav/main.tf
@@ -1,7 +1,3 @@
-###
-# Target space/org
-###
-
 data "cloudfoundry_space" "space" {
   org_name = var.cf_org_name
   name     = var.cf_space_name
@@ -16,18 +12,14 @@ data "cloudfoundry_app" "app" {
   space      = data.cloudfoundry_space.space.id
 }
 
-###
-# ClamAV API app
-###
-
 resource "cloudfoundry_route" "clamav_route" {
   space    = data.cloudfoundry_space.space.id
   domain   = data.cloudfoundry_domain.internal.id
-  hostname = "${var.app_name}-clamapi-${var.env}"
+  hostname = var.name
 }
 
 resource "cloudfoundry_app" "clamav_api" {
-  name         = "${var.app_name}-clamav-api-${var.env}"
+  name         = var.name
   space        = data.cloudfoundry_space.space.id
   memory       = var.clamav_memory
   disk_quota   = 2048

--- a/clamav/variables.tf
+++ b/clamav/variables.tf
@@ -25,14 +25,9 @@ variable "cf_space_name" {
   description = "cloud.gov space name (staging or prod)"
 }
 
-variable "app_name" {
+variable "name" {
   type        = string
-  description = "base application name to be scanned by clamav"
-}
-
-variable "env" {
-  type        = string
-  description = "deployment environment (staging, production)"
+  description = "name of the clamav scanning application"
 }
 
 variable "clamav_image" {

--- a/database/main.tf
+++ b/database/main.tf
@@ -1,22 +1,14 @@
-###
-# Target space/org
-###
-
 data "cloudfoundry_space" "space" {
   org_name = var.cf_org_name
   name     = var.cf_space_name
 }
-
-###
-# RDS instance
-###
 
 data "cloudfoundry_service" "rds" {
   name = "aws-rds"
 }
 
 resource "cloudfoundry_service_instance" "rds" {
-  name             = "${var.app_name}-rds-${var.env}"
+  name             = var.name
   space            = data.cloudfoundry_space.space.id
   service_plan     = data.cloudfoundry_service.rds.service_plans[var.rds_plan_name]
   recursive_delete = var.recursive_delete

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -22,17 +22,12 @@ variable "cf_org_name" {
 
 variable "cf_space_name" {
   type        = string
-  description = "cloud.gov space name (staging or prod)"
+  description = "cloud.gov space name"
 }
 
-variable "env" {
+variable "name" {
   type        = string
-  description = "deployment environment (staging, production)"
-}
-
-variable "app_name" {
-  type        = string
-  description = "base application name that will connect to this database"
+  description = "Name of the database service instance"
 }
 
 variable "recursive_delete" {
@@ -43,5 +38,6 @@ variable "recursive_delete" {
 
 variable "rds_plan_name" {
   type        = string
-  description = "name of the service plan name to create"
+  description = "service plan to use"
+  # See options at https://cloud.gov/docs/services/relational-database/#plans
 }

--- a/domain/main.tf
+++ b/domain/main.tf
@@ -1,18 +1,10 @@
-###
-# Target space/org
-###
-
 data "cloudfoundry_space" "space" {
   org_name = var.cf_org_name
   name     = var.cf_space_name
 }
 
-###
-# Route mapping and CDN instance
-###
-
 data "cloudfoundry_app" "app" {
-  name_or_id = "${var.app_name}-${var.env}"
+  name_or_id = var.app_name_or_id
   space      = data.cloudfoundry_space.space.id
 }
 
@@ -38,7 +30,7 @@ data "cloudfoundry_service" "external_domain" {
 }
 
 resource "cloudfoundry_service_instance" "external_domain_instance" {
-  name             = "${var.app_name}-domain-${var.env}"
+  name             = data.cloudfoundry_app.name
   space            = data.cloudfoundry_space.space.id
   service_plan     = data.cloudfoundry_service.external_domain.service_plans[var.cdn_plan_name]
   recursive_delete = var.recursive_delete

--- a/domain/variables.tf
+++ b/domain/variables.tf
@@ -25,12 +25,7 @@ variable "cf_space_name" {
   description = "cloud.gov space name (staging or prod)"
 }
 
-variable "env" {
-  type        = string
-  description = "deployment environment (staging, production)"
-}
-
-variable "app_name" {
+variable "app_name_or_id" {
   type        = string
   description = "base application name to be accessed at this domain name"
 }

--- a/redis/main.tf
+++ b/redis/main.tf
@@ -1,22 +1,14 @@
-###
-# Target space/org
-###
-
 data "cloudfoundry_space" "space" {
   org_name = var.cf_org_name
   name     = var.cf_space_name
 }
-
-###
-# RDS instance
-###
 
 data "cloudfoundry_service" "redis" {
   name = "aws-elasticache-redis"
 }
 
 resource "cloudfoundry_service_instance" "redis" {
-  name             = "${var.app_name}-redis-${var.env}"
+  name             = var.name
   space            = data.cloudfoundry_space.space.id
   service_plan     = data.cloudfoundry_service.redis.service_plans[var.redis_plan_name]
   recursive_delete = var.recursive_delete

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -25,14 +25,9 @@ variable "cf_space_name" {
   description = "cloud.gov space name (staging or prod)"
 }
 
-variable "env" {
+variable "name" {
   type        = string
-  description = "deployment environment (staging, production)"
-}
-
-variable "app_name" {
-  type        = string
-  description = "base application name that will use this redis instance"
+  description = "name for the redis service instance"
 }
 
 variable "recursive_delete" {

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,22 +1,14 @@
-###
-# Target space/org
-###
-
 data "cloudfoundry_space" "space" {
   org_name = var.cf_org_name
   name     = var.cf_space_name
 }
-
-###
-# S3 instance
-###
 
 data "cloudfoundry_service" "s3" {
   name = "s3"
 }
 
 resource "cloudfoundry_service_instance" "bucket" {
-  name             = var.s3_service_name
+  name             = var.name
   space            = data.cloudfoundry_space.space.id
   service_plan     = data.cloudfoundry_service.s3.service_plans[var.s3_plan_name]
   recursive_delete = var.recursive_delete

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -31,13 +31,14 @@ variable "recursive_delete" {
   default     = false
 }
 
-variable "s3_service_name" {
+variable "name" {
   type        = string
-  description = "name for the cloud.gov managed service"
+  description = "name of the cloud.gov service instance"
 }
 
 variable "s3_plan_name" {
   type        = string
-  description = "name of the service plan to create"
+  description = "service plan to use"
   default     = "basic"
+  # See options at https://cloud.gov/docs/services/s3/#plans
 }


### PR DESCRIPTION
**NOTE: THIS IS A BREAKING CHANGE**

Modules shouldn't know anything about environments or what applications the services might be bound to. The calling module should specify the name using its own context/convention, rather than the module making assumptions.