### PR TITLE
Bump suggested clamav-rest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Creates an application and associated network routing to run ClamAV via API to s
 
 Notes:
 * The scanning app requires at least `3GB` of memory, and your `app_name` must be deployed before this module is included.
-* Module `>= v0.3.0` requires `TAG_NAME` being `>= 20230224`.
+* Module `>= v0.3.0` requires `TAG_NAME` being `>= 20230228`.
 
 ```
 module "clamav" {


### PR DESCRIPTION
See https://github.com/ajilach/clamav-rest/issues/15. Technically this version is not required for module version 0.3.0, but a lot of people are going to just blindly copy the suggested tag here so we may as well start them from that one.