### PR TITLE
Update environment to support proxy

### DIFF
--- a/clamav/main.tf
+++ b/clamav/main.tf
@@ -33,8 +33,11 @@ resource "cloudfoundry_app" "clamav_api" {
     # Only set "https_proxy" if a value was supplied.
     # Otherwise, ensure that a harmless envvar gets set instead.
     # This avoids confusing the app with an https_proxy that's set to ""!
-    "${var.https_proxy != "" ? "https_proxy" : "https_proxy_is_not_set"}" = var.https_proxy
-    MAX_FILE_SIZE                                                         = var.max_file_size
+    "${var.https_proxy != "" ? "PROXY_SERVER" : "https_proxy_is_not_set"}"         = var.https_proxy
+    "${var.proxy_port != "" ? "PROXY_PORT" : "proxy_port_is_not_set"}"             = var.proxy_port
+    "${var.proxy_username != "" ? "PROXY_USERNAME" : "proxy_username_is_not_set"}" = var.proxy_username
+    "${var.proxy_password != "" ? "PROXY_PASSWORD" : "proxy_password_is_not_set"}" = var.proxy_password
+    MAX_FILE_SIZE                                                                  = var.max_file_size
   }
 }
 

--- a/clamav/variables.tf
+++ b/clamav/variables.tf
@@ -39,3 +39,21 @@ variable "https_proxy" {
   description = "https_proxy to use for outbound connections, eg to database.freshclam.net"
   default     = ""
 }
+
+variable "proxy_port" {
+  type        = string
+  description = "port for use with https_proxy, eg 61443"
+  default     = ""
+}
+
+variable "proxy_username" {
+  type        = string
+  description = "username for https_proxy, eg a-username"
+  default     = ""
+}
+
+variable "proxy_password" {
+  type        = string
+  description = "password for https_proxy, eg a-password"
+  default     = ""
+}


### PR DESCRIPTION
After creating a fork of clamav inside the GSA-TTS Org, we are proposing the following changes so that we may pass the environment variables necessary for freshclam proxy.

In parallel, we would be refactoring our https-proxy to now [output these items](https://github.com/GSA-TTS/FAC/pull/1174/files) specifically as:

```tf
  https_proxy    = module.https-proxy.https_proxy
  proxy_port     = module.https_proxy.port
  proxy_username = module.https_proxy.username
  proxy_password = module.https_proxy.password
```

to be consumed here, and set the ENV vars for the following items [updated entrypoint.sh](https://github.com/GSA-TTS/clamav-rest/blob/9a388c8d4aa8815797ba1c0b9521ae1fe7f6ed55/entrypoint.sh#L19-L32):
```sh
$PROXY_SERVER
$PROXY_PORT
$PROXY_USERNAME
$PROXY_PASSWORD
```