### PR TITLE
Support hostname when setting up a route+domain service

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ Note that the domain must be created in cloud.gov by an OrgManager before this m
 
 ```
 module "domain" {
-  source = "github.com/18f/terraform-cloudgov//domain?ref=v0.6.0"
+  source = "github.com/18f/terraform-cloudgov//domain?ref=v0.7.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   app_name_or_id   = "app_name"
   cdn_plan_name    = "domain"
   domain_name      = "my-production-domain-name"
+  host_name        = "my-production-host-name"
 }
 ```
 

--- a/domain/main.tf
+++ b/domain/main.tf
@@ -1,5 +1,6 @@
 locals {
   service_name = (var.name == "" ? "${data.cloudfoundry_app.app.name}-${var.domain_name}" : var.name)
+  endpoint     = (var.host_name != null ? "${var.host_name}.${var.domain_name}" : var.domain_name)
 }
 
 data "cloudfoundry_space" "space" {
@@ -25,8 +26,9 @@ data "cloudfoundry_domain" "origin_url" {
 }
 
 resource "cloudfoundry_route" "origin_route" {
-  domain = data.cloudfoundry_domain.origin_url.id
-  space  = data.cloudfoundry_space.space.id
+  domain   = data.cloudfoundry_domain.origin_url.id
+  hostname = var.host_name
+  space    = data.cloudfoundry_space.space.id
   target {
     app = data.cloudfoundry_app.app.id
   }
@@ -41,5 +43,5 @@ resource "cloudfoundry_service_instance" "external_domain_instance" {
   space            = data.cloudfoundry_space.space.id
   service_plan     = data.cloudfoundry_service.external_domain.service_plans[var.cdn_plan_name]
   recursive_delete = var.recursive_delete
-  json_params      = "{\"domains\": \"${var.domain_name}\"}"
+  json_params      = "{\"domains\": \"${local.endpoint}\"}"
 }

--- a/domain/variables.tf
+++ b/domain/variables.tf
@@ -32,5 +32,11 @@ variable "cdn_plan_name" {
 
 variable "domain_name" {
   type        = string
-  description = "DNS name users will be accessing site"
+  description = "Domain name users will use to access the application"
+}
+
+variable "host_name" {
+  type        = string
+  description = "Host name users will use to access the application"
+  default     = null
 }


### PR DESCRIPTION
For example, one might want their app mapped to the FQDN "app.fac.gov", not just "fac.gov". 😉