### PR TITLE
Add instances for clamav

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ module "clamav" {
   name           = "my_clamav_name"
   clamav_image   = "ghcr.io/gsa-tts/clamav-rest/clamav:TAG_NAME"
   max_file_size  = "30M"
+  instances      = 2
   proxy_server   = local.proxy_server # https proxy to reach database.clamav.net:443, if necessary
   proxy_port     = local.proxy_port
   proxy_username = local.proxy_username

--- a/clamav/main.tf
+++ b/clamav/main.tf
@@ -25,6 +25,7 @@ resource "cloudfoundry_app" "clamav_api" {
   disk_quota   = 2048
   timeout      = 600
   strategy     = "rolling"
+  instances    = var.instances
   docker_image = var.clamav_image
   routes {
     route = cloudfoundry_route.clamav_route.id

--- a/clamav/variables.tf
+++ b/clamav/variables.tf
@@ -57,3 +57,9 @@ variable "proxy_password" {
   description = "password for proxy_server, eg a-password"
   default     = ""
 }
+
+variable "instances" {
+  type        = number
+  description = "the number of instances that the clamav module should operate (default 1)"
+  default     = 1
+}

--- a/semver/tests/default/default.tf
+++ b/semver/tests/default/default.tf
@@ -16,7 +16,7 @@ locals {
     # This test will break after we tag something higher than 1.0.0; fix and
     # expand these tests then!
     # https://github.com/npm/node-semver#tilde-ranges-123-12-1
-    greaterthan = "~0", 
+    greaterthan = "~0",
   }
 
   latest_tag = trimprefix(jsondecode(data.http.latest_version.response_body).tag_name, "v")
@@ -41,8 +41,8 @@ resource "test_assertions" "greater-than-is-latest" {
   component = "outputs"
   equal "target_version" {
     description = "greater than should always be the latest in the repo"
-    got  = module.version["greaterthan"].target_version
-    want = local.latest_tag
+    got         = module.version["greaterthan"].target_version
+    want        = local.latest_tag
   }
 }
 


### PR DESCRIPTION
This PR adds instances to clamav, so that we can scale them on demand with a single module call.