### PR TITLE
Adds `json_params` as an input

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ module "database" {
   name             = "database_name"
   rds_plan_name    = "micro-psql"
   tags             = ["tag1", "tag2"]
+  json_params      = jsonencode(
+    {
+      "storage" : 10,
+    }
+  )
 }
 ```
 
@@ -56,6 +61,11 @@ module "redis" {
   name             = "redis_name"
   redis_plan_name  = "redis-dev"
   tags             = ["tag1", "tag2"]
+  json_params      = jsonencode(
+    {
+      "engineVersion" : "6.2",
+    }
+  )
 }
 ```
 
@@ -71,6 +81,11 @@ module "s3" {
   cf_space_name    = local.cf_space_name
   name             = "${local.app_name}-s3-${local.env}"
   tags             = ["tag1", "tag2"]
+  json_params      = jsonencode(
+    {
+      "object_ownership" : "ObjectWriter",
+    }
+  )
 }
 ```
 

--- a/database/main.tf
+++ b/database/main.tf
@@ -13,4 +13,5 @@ resource "cloudfoundry_service_instance" "rds" {
   service_plan     = data.cloudfoundry_service.rds.service_plans[var.rds_plan_name]
   recursive_delete = var.recursive_delete
   tags             = var.tags
+  json_params      = var.json_params
 }

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -34,6 +34,6 @@ variable "tags" {
 variable "json_params" {
   description = "A JSON string of arbitrary parameters"
   type        = map(object)
-  default     = false
+  default     = null
   # See options at https://cloud.gov/docs/services/relational-database/#setting-optional-parameters-1
 }

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -30,3 +30,10 @@ variable "tags" {
   type        = list(string)
   default     = []
 }
+
+variable "json_params" {
+  description = "A JSON string of arbitrary parameters"
+  type        = map(object)
+  default     = false
+  # See options at https://cloud.gov/docs/services/relational-database/#setting-optional-parameters-1
+}

--- a/redis/main.tf
+++ b/redis/main.tf
@@ -13,4 +13,5 @@ resource "cloudfoundry_service_instance" "redis" {
   service_plan     = data.cloudfoundry_service.redis.service_plans[var.redis_plan_name]
   recursive_delete = var.recursive_delete
   tags             = var.tags
+  json_params      = var.json_params
 }

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -29,3 +29,10 @@ variable "tags" {
   type        = list(string)
   default     = []
 }
+
+variable "json_params" {
+  description = "A JSON string of arbitrary parameters"
+  type        = map(object)
+  default     = false
+  # See options at https://cloud.gov/docs/services/aws-elasticache/#setting-optional-parameters
+}

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -33,6 +33,6 @@ variable "tags" {
 variable "json_params" {
   description = "A JSON string of arbitrary parameters"
   type        = map(object)
-  default     = false
+  default     = null
   # See options at https://cloud.gov/docs/services/aws-elasticache/#setting-optional-parameters
 }

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -13,4 +13,5 @@ resource "cloudfoundry_service_instance" "bucket" {
   service_plan     = data.cloudfoundry_service.s3.service_plans[var.s3_plan_name]
   recursive_delete = var.recursive_delete
   tags             = var.tags
+  json_params      = var.json_params
 }

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -35,7 +35,7 @@ variable "tags" {
 variable "json_params" {
   description = "A JSON string of arbitrary parameters"
   type        = map(string)
-  default     = false
+  default     = null
   # See options at https://cloud.gov/docs/services/s3/#setting-optional-parameters
 }
 

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -31,3 +31,11 @@ variable "tags" {
   type        = list(string)
   default     = []
 }
+
+variable "json_params" {
+  description = "A JSON string of arbitrary parameters"
+  type        = map(string)
+  default     = false
+  # See options at https://cloud.gov/docs/services/s3/#setting-optional-parameters
+}
+


### PR DESCRIPTION
Instead of manually doing `cf update-service ${service_name} -c '{"key":"value"}'` lets do it with terraform allowing us to specify additional arguments in json format.
```terraform
> jsonencode({"storage" : 10,})
"{\"storage\":10}"
```